### PR TITLE
Fix Issue #15: Hide redundant SIGN IN button on login page

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,18 +6,22 @@ This document tracks known issues and their status for the PBS Member Portal CSS
 
 ## Open Issues
 
-### Issue #14: Resource library folders don't collapse when minus clicked
+### Issue #15: Redundant SIGN IN button on login page
 - **Status:** Open
 - **Priority:** Medium
-- **Affected page(s):** Resource Library / Document pages
-- **Description:** Folders in the resource library expand when the plus (+) is clicked, but do not contract/collapse when minus (-) is clicked
-- **Expected behavior:** Clicking minus should collapse the expanded folder
+- **Affected page(s):** Login page (Sign_In.aspx)
+- **Description:** A "SIGN IN" button appears in the top left header area on the login page, which is redundant since users are already on the sign-in page with a form submit button
+- **Expected behavior:** Hide SIGN IN button on login page only, while keeping SIGN OUT button visible on authenticated pages
 - **Viewport:** Desktop and Mobile
-- **Screenshot:** TBD
+- **Screenshot:** automatedTestScreenshots/1440p-login-*.png
 
 ---
 
 ## Resolved Issues
+
+### Issue #14: Resource library folders don't collapse when minus clicked
+- **Status:** Resolved (2026-02-02)
+- **Fix:** Removed `!important` from `.rtUL` display rules and added attribute selector `[style*="display: none"]` to respect JavaScript's inline styles when collapsing folders.
 
 ### Issue #13: Banner image "Membership Database" text cut off at 1440p
 - **Status:** Resolved (2026-02-02)
@@ -107,4 +111,4 @@ Screenshots are saved to `automatedTestScreenshots/` folder.
 
 ---
 
-*Last updated: 2026-01-31*
+*Last updated: 2026-02-02*

--- a/package/pbs-theme.css
+++ b/package/pbs-theme.css
@@ -4441,3 +4441,40 @@ body:has([id*="ciNewContactSignInCommon"]) [id*="signInDiv"] {
         gap: 5px !important;
     }
 }
+
+/* ========================================
+   Issue #15: HIDE SIGN IN BUTTON ON LOGIN PAGE ONLY
+   The auth-link shows "Sign In" on login page, "Sign Out" when authenticated.
+   We must hide it on login page (redundant) but keep it visible elsewhere.
+   Uses maximum specificity to override the visibility rules above.
+   ======================================== */
+
+/* Target the Sign In button specifically on login page */
+/* Use body:has() to detect login page by presence of sign-in form elements */
+html body:has([id*="ciNewContactSignInCommon"]) .auth-link-container,
+html body:has([id*="ciNewContactSignInCommon"]) .auth-link-container a,
+html body:has([id*="ciNewContactSignInCommon"]) .auth-link-container a.auth-link,
+html body:has([id*="ciNewContactSignInCommon"]) a#ctl01_LoginStatus1,
+html body:has([id*="ciNewContactSignInCommon"]) #ctl01_LoginStatus1,
+html body:has([id*="ciNewContactSignInCommon"]) a.auth-link,
+html body:has([id*="ciNewContactSignInCommon"]) a[id*="LoginStatus"],
+html body:has([id*="signInDiv"]) .auth-link-container,
+html body:has([id*="signInDiv"]) .auth-link-container a,
+html body:has([id*="signInDiv"]) .auth-link-container a.auth-link,
+html body:has([id*="signInDiv"]) a#ctl01_LoginStatus1,
+html body:has([id*="signInDiv"]) #ctl01_LoginStatus1,
+html body:has([id*="signInDiv"]) a.auth-link,
+html body:has([id*="signInDiv"]) a[id*="LoginStatus"] {
+    display: none !important;
+    visibility: hidden !important;
+    width: 0 !important;
+    height: 0 !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    border: none !important;
+    overflow: hidden !important;
+    position: absolute !important;
+    left: -9999px !important;
+    opacity: 0 !important;
+    pointer-events: none !important;
+}

--- a/test-signin-button.js
+++ b/test-signin-button.js
@@ -1,0 +1,225 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+const fs = require('fs');
+
+const SCREENSHOTS_DIR = './automatedTestScreenshots';
+const BASE_URL = 'https://members.phibetasigma1914.org/iMISDEV';
+
+// Load local CSS to inject
+const localCSS = fs.readFileSync(path.join(__dirname, 'package', 'pbs-theme.css'), 'utf8');
+
+const username = process.argv[2];
+const password = process.argv[3];
+
+const wait = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+async function testSignInButton() {
+    console.log('Testing SIGN IN button visibility on login page...\n');
+
+    const browser = await puppeteer.launch({
+        headless: false,
+        defaultViewport: { width: 1400, height: 900 }
+    });
+
+    const page = await browser.newPage();
+
+    try {
+        // Go to login page
+        console.log('1. Navigating to login page...');
+        await page.goto(`${BASE_URL}/PBSMember/Sign_In.aspx`, { waitUntil: 'networkidle2', timeout: 60000 });
+        await wait(2000);
+
+        // Screenshot BEFORE CSS injection
+        const beforeScreenshot = path.join(SCREENSHOTS_DIR, `signin-1-before-css-${Date.now()}.png`);
+        await page.screenshot({ path: beforeScreenshot });
+        console.log(`   Screenshot (before CSS): ${beforeScreenshot}`);
+
+        // Debug: Find all potential Sign In buttons/links
+        console.log('\n2. Inspecting DOM for Sign In elements...');
+        const signInElements = await page.evaluate(() => {
+            const results = [];
+
+            // Find all links/buttons with Sign In or LoginStatus
+            const selectors = [
+                'a[id*="LoginStatus"]',
+                'a[id*="SignIn"]',
+                'a[href*="Sign_In"]',
+                'a:contains("SIGN IN")',
+                '[id*="LoginStatus"]',
+                '.TextButton',
+                '#hd a',
+                '.auth-link',
+                'a.TextButton'
+            ];
+
+            // Check all links in header
+            const headerLinks = document.querySelectorAll('#hd a, .header-top-container a, [class*="header"] a');
+            headerLinks.forEach(el => {
+                const text = el.textContent.trim();
+                if (text.toLowerCase().includes('sign') || el.id.toLowerCase().includes('login') || el.id.toLowerCase().includes('sign')) {
+                    results.push({
+                        tag: el.tagName,
+                        id: el.id,
+                        className: el.className,
+                        href: el.href,
+                        text: text,
+                        parentId: el.parentElement?.id,
+                        parentClass: el.parentElement?.className,
+                        display: window.getComputedStyle(el).display,
+                        visibility: window.getComputedStyle(el).visibility
+                    });
+                }
+            });
+
+            // Also find anything with SIGN IN text
+            const allElements = document.querySelectorAll('a, button, input[type="submit"]');
+            allElements.forEach(el => {
+                const text = el.textContent?.trim() || el.value?.trim() || '';
+                if (text.toUpperCase() === 'SIGN IN' && !results.find(r => r.id === el.id)) {
+                    results.push({
+                        tag: el.tagName,
+                        id: el.id,
+                        className: el.className,
+                        href: el.href || '',
+                        text: text,
+                        parentId: el.parentElement?.id,
+                        parentClass: el.parentElement?.className,
+                        display: window.getComputedStyle(el).display,
+                        visibility: window.getComputedStyle(el).visibility
+                    });
+                }
+            });
+
+            return results;
+        });
+
+        console.log('\n   Found Sign In related elements:');
+        signInElements.forEach((el, i) => {
+            console.log(`\n   [${i + 1}] ${el.tag} - "${el.text}"`);
+            console.log(`       id: ${el.id}`);
+            console.log(`       class: ${el.className}`);
+            console.log(`       href: ${el.href}`);
+            console.log(`       parent id: ${el.parentId}`);
+            console.log(`       parent class: ${el.parentClass}`);
+            console.log(`       display: ${el.display}, visibility: ${el.visibility}`);
+        });
+
+        // Check for :has() selector support
+        console.log('\n3. Checking :has() selector support...');
+        const hasSupport = await page.evaluate(() => {
+            try {
+                document.querySelector(':has(*)');
+                return true;
+            } catch (e) {
+                return false;
+            }
+        });
+        console.log(`   :has() selector supported: ${hasSupport}`);
+
+        // Check if sign-in form identifiers exist
+        console.log('\n4. Checking for login page identifiers...');
+        const loginIdentifiers = await page.evaluate(() => {
+            return {
+                ciNewContactSignInCommon: !!document.querySelector('[id*="ciNewContactSignInCommon"]'),
+                signInDiv: !!document.querySelector('[id*="signInDiv"]'),
+                signInPanel: !!document.querySelector('[id*="SignInPanel"]'),
+                signInUserName: !!document.querySelector('[id*="signInUserName"]'),
+                allSignInIds: [...document.querySelectorAll('[id*="signIn"], [id*="SignIn"]')].map(el => el.id).slice(0, 10)
+            };
+        });
+        console.log(`   ciNewContactSignInCommon: ${loginIdentifiers.ciNewContactSignInCommon}`);
+        console.log(`   signInDiv: ${loginIdentifiers.signInDiv}`);
+        console.log(`   signInPanel: ${loginIdentifiers.signInPanel}`);
+        console.log(`   signInUserName: ${loginIdentifiers.signInUserName}`);
+        console.log(`   Sample IDs: ${loginIdentifiers.allSignInIds.join(', ')}`);
+
+        // Inject local CSS
+        console.log('\n5. Injecting local CSS...');
+        await page.addStyleTag({ content: localCSS });
+        await wait(1000);
+
+        // Screenshot AFTER CSS injection
+        const afterScreenshot = path.join(SCREENSHOTS_DIR, `signin-2-after-css-${Date.now()}.png`);
+        await page.screenshot({ path: afterScreenshot });
+        console.log(`   Screenshot (after CSS): ${afterScreenshot}`);
+
+        // Check if Sign In button is now hidden
+        console.log('\n6. Checking Sign In button visibility after CSS...');
+        const afterCSSCheck = await page.evaluate(() => {
+            const results = [];
+            const headerLinks = document.querySelectorAll('#hd a, .header-top-container a');
+            headerLinks.forEach(el => {
+                const text = el.textContent.trim();
+                if (text.toUpperCase().includes('SIGN')) {
+                    const style = window.getComputedStyle(el);
+                    results.push({
+                        text: text,
+                        id: el.id,
+                        display: style.display,
+                        visibility: style.visibility,
+                        width: style.width,
+                        height: style.height,
+                        isHidden: style.display === 'none' || style.visibility === 'hidden'
+                    });
+                }
+            });
+            return results;
+        });
+
+        afterCSSCheck.forEach(el => {
+            const status = el.isHidden ? '✅ HIDDEN' : '❌ VISIBLE';
+            console.log(`   ${status}: "${el.text}" (id=${el.id}, display=${el.display}, visibility=${el.visibility})`);
+        });
+
+        // Now login and check SIGN OUT is visible
+        if (username && password) {
+            console.log('\n7. Logging in to verify SIGN OUT remains visible...');
+            await page.type('input[id*="UserName"]', username);
+            await page.type('input[id*="Password"]', password);
+            await page.click('input[type="submit"], button[type="submit"], input[id*="LoginButton"]');
+            await page.waitForNavigation({ waitUntil: 'networkidle2', timeout: 60000 });
+            await wait(2000);
+
+            // Screenshot authenticated page
+            const authScreenshot = path.join(SCREENSHOTS_DIR, `signin-3-authenticated-${Date.now()}.png`);
+            await page.screenshot({ path: authScreenshot });
+            console.log(`   Screenshot (authenticated): ${authScreenshot}`);
+
+            // Check SIGN OUT is visible
+            console.log('\n8. Checking SIGN OUT button visibility...');
+            const signOutCheck = await page.evaluate(() => {
+                const results = [];
+                const allLinks = document.querySelectorAll('a');
+                allLinks.forEach(el => {
+                    const text = el.textContent.trim();
+                    if (text.toUpperCase().includes('SIGN OUT') || text.toUpperCase().includes('LOGOUT') || el.id.toLowerCase().includes('logout') || el.id.toLowerCase().includes('signout')) {
+                        const style = window.getComputedStyle(el);
+                        results.push({
+                            text: text,
+                            id: el.id,
+                            display: style.display,
+                            visibility: style.visibility,
+                            isVisible: style.display !== 'none' && style.visibility !== 'hidden'
+                        });
+                    }
+                });
+                return results;
+            });
+
+            signOutCheck.forEach(el => {
+                const status = el.isVisible ? '✅ VISIBLE' : '❌ HIDDEN';
+                console.log(`   ${status}: "${el.text}" (id=${el.id}, display=${el.display})`);
+            });
+        }
+
+        console.log('\n✓ Test complete! Check automatedTestScreenshots/ for results.');
+        console.log('Browser left open for inspection.');
+
+    } catch (error) {
+        console.error('Error:', error.message);
+        const errorScreenshot = path.join(SCREENSHOTS_DIR, `signin-error-${Date.now()}.png`);
+        await page.screenshot({ path: errorScreenshot });
+    }
+}
+
+testSignInButton();


### PR DESCRIPTION
## Summary
- Hide the SIGN IN button on login page (redundant since users are already on the sign-in form)
- Sign Out button remains visible on authenticated pages (same element ID, different page context)
- Uses CSS `:has()` selector to detect login page by presence of sign-in form elements

## Test plan
- [x] Verify SIGN IN button is hidden on login page
- [x] Verify SIGN OUT button remains visible on authenticated pages
- [x] Verify banner image still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)