### PR TITLE
Fix report page date picker calendar buttons

### DIFF
--- a/package/pbs-theme.css
+++ b/package/pbs-theme.css
@@ -5189,6 +5189,81 @@ html body a.rcCalPopup::after,
 }
 
 /* ========================================
+   FIX: BusinessCalendar Date Picker Controls (Reports)
+   These use input[type="image"] with empty src - need to provide visible icon
+   ======================================== */
+
+/* BusinessCalendar image button - the src is broken so we need to style it as a visible button */
+input[type="image"][id*="BusinessCalendar"],
+input[type="image"][id*="Calendar_ImageButton"],
+input[type="image"][alt="Use calendar"],
+.GridFilterCalendar input[type="image"] {
+    display: inline-block !important;
+    visibility: visible !important;
+    width: 28px !important;
+    height: 28px !important;
+    min-width: 28px !important;
+    min-height: 28px !important;
+    padding: 0 !important;
+    margin-left: 4px !important;
+    vertical-align: middle !important;
+    cursor: pointer !important;
+    /* Hide the broken image alt text */
+    font-size: 0 !important;
+    color: transparent !important;
+    text-indent: -9999px !important;
+    overflow: hidden !important;
+    /* Style as calendar button */
+    background-color: var(--pbs-blue) !important;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23ffffff'%3E%3Cpath d='M19 4h-1V2h-2v2H8V2H6v2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V10h14v10zm0-12H5V6h14v2z'/%3E%3C/svg%3E") !important;
+    background-size: 18px 18px !important;
+    background-repeat: no-repeat !important;
+    background-position: center !important;
+    border: 1px solid var(--pbs-blue) !important;
+    border-radius: 4px !important;
+    /* Ensure the broken image icon is hidden */
+    object-fit: none !important;
+    object-position: -9999px -9999px !important;
+}
+
+input[type="image"][id*="BusinessCalendar"]:hover,
+input[type="image"][id*="Calendar_ImageButton"]:hover,
+input[type="image"][alt="Use calendar"]:hover,
+.GridFilterCalendar input[type="image"]:hover {
+    background-color: var(--pbs-blue-dark) !important;
+    border-color: var(--pbs-blue-dark) !important;
+}
+
+/* GridFilterCalendar table layout */
+.GridFilterCalendar {
+    border-collapse: separate !important;
+    border-spacing: 4px !important;
+}
+
+.GridFilterCalendar td {
+    vertical-align: middle !important;
+    padding: 2px 4px !important;
+}
+
+/* StylesDateText input - the date text field */
+.StylesDateText,
+input.StylesDateText {
+    padding: 6px 10px !important;
+    border: 1px solid var(--pbs-gray-300) !important;
+    border-radius: 4px !important;
+    font-size: 14px !important;
+    min-width: 100px !important;
+    background-color: var(--pbs-white) !important;
+}
+
+.StylesDateText:focus,
+input.StylesDateText:focus {
+    border-color: var(--pbs-blue) !important;
+    outline: none !important;
+    box-shadow: 0 0 4px rgba(22, 79, 144, 0.3) !important;
+}
+
+/* ========================================
    RadCalendar Popup Styling - Issue #20
    ======================================== */
 

--- a/test-report-datepicker.js
+++ b/test-report-datepicker.js
@@ -1,0 +1,148 @@
+const puppeteer = require('puppeteer');
+const path = require('path');
+const fs = require('fs');
+const { getCredentials } = require('./test-config');
+
+const LOGIN_URL = 'https://members.phibetasigma1914.org/iMISdev/';
+const REPORT_URL = 'https://members.phibetasigma1914.org/iMISDEV/PBSMember/HQ_Items/Reports/LMS_Course_Completion_Report/PBSMember/LMS_Course_Completion_Report.aspx?hkey=e20d384d-d774-440f-8e64-912764acb195';
+const THEME_BASE_URL = 'https://members.phibetasigma1914.org/iMISdev/App_Themes/PBS_Responsive_Theme';
+const LOCAL_CSS_PATH = path.join(__dirname, 'package', 'pbs-theme.css');
+const SCREENSHOT_DIR = path.join(__dirname, 'testingScreenshots');
+
+async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function testReportDatePicker() {
+    // Use mcornelius user (index 1) - has staff access to reports
+    const { username, password } = getCredentials(1);
+    console.log('Using user:', username);
+
+    // Load local CSS and fix image paths
+    let localCss = fs.readFileSync(LOCAL_CSS_PATH, 'utf8');
+    localCss = localCss.replace(/url\("images\//g, `url("${THEME_BASE_URL}/images/`);
+
+    const browser = await puppeteer.launch({ headless: false, protocolTimeout: 120000 });
+    const page = await browser.newPage();
+    await page.setViewport({ width: 1400, height: 900 });
+    page.on('dialog', async d => await d.accept());
+
+    try {
+        // Login
+        console.log('Logging in...');
+        await page.goto(LOGIN_URL, { waitUntil: 'networkidle2' });
+        await page.type('#ctl01_TemplateBody_WebPartManager1_gwpciNewContactSignInCommon_ciNewContactSignInCommon_signInUserName', username);
+        await page.type('#ctl01_TemplateBody_WebPartManager1_gwpciNewContactSignInCommon_ciNewContactSignInCommon_signInPassword', password);
+        await page.evaluate(() => document.querySelector('#ctl01_TemplateBody_WebPartManager1_gwpciNewContactSignInCommon_ciNewContactSignInCommon_SubmitButton').click());
+        await sleep(6000);
+        console.log('Logged in! Current URL:', page.url());
+
+        // Navigate to LMS Report page
+        console.log('Navigating to LMS Course Completion Report...');
+        await page.goto(REPORT_URL, { waitUntil: 'networkidle2', timeout: 30000 });
+        await sleep(2000);
+
+        // Screenshot BEFORE CSS injection
+        await page.screenshot({ path: path.join(SCREENSHOT_DIR, 'report-datepicker-1-before-css.png'), fullPage: false });
+        console.log('Screenshot: report-datepicker-1-before-css.png');
+
+        // Analyze date picker elements before CSS
+        const beforeAnalysis = await page.evaluate(() => {
+            const results = {
+                gridFilterCalendar: [],
+                imageButtons: [],
+                dateInputs: []
+            };
+
+            // Find GridFilterCalendar tables
+            document.querySelectorAll('.GridFilterCalendar').forEach(table => {
+                const rect = table.getBoundingClientRect();
+                results.gridFilterCalendar.push({
+                    width: rect.width,
+                    height: rect.height,
+                    visible: rect.width > 0 && rect.height > 0
+                });
+            });
+
+            // Find image buttons (calendar buttons)
+            document.querySelectorAll('input[type="image"]').forEach(img => {
+                const rect = img.getBoundingClientRect();
+                const style = getComputedStyle(img);
+                results.imageButtons.push({
+                    id: img.id.substring(img.id.length - 40),
+                    alt: img.alt,
+                    src: img.src,
+                    width: rect.width,
+                    height: rect.height,
+                    display: style.display,
+                    visibility: style.visibility,
+                    visible: rect.width > 0 && rect.height > 0
+                });
+            });
+
+            // Find date text inputs
+            document.querySelectorAll('.StylesDateText, input[id*="BusinessCalendar"]').forEach(input => {
+                const rect = input.getBoundingClientRect();
+                results.dateInputs.push({
+                    id: input.id.substring(input.id.length - 30),
+                    className: input.className,
+                    width: rect.width,
+                    visible: rect.width > 0
+                });
+            });
+
+            return results;
+        });
+
+        console.log('\n=== BEFORE CSS INJECTION ===');
+        console.log('GridFilterCalendar tables:', JSON.stringify(beforeAnalysis.gridFilterCalendar, null, 2));
+        console.log('Image buttons (calendar):', JSON.stringify(beforeAnalysis.imageButtons, null, 2));
+        console.log('Date inputs:', JSON.stringify(beforeAnalysis.dateInputs, null, 2));
+
+        // Inject local CSS
+        console.log('\nInjecting local CSS...');
+        await page.addStyleTag({ content: localCss });
+        await sleep(1000);
+
+        // Screenshot AFTER CSS injection
+        await page.screenshot({ path: path.join(SCREENSHOT_DIR, 'report-datepicker-2-after-css.png'), fullPage: false });
+        console.log('Screenshot: report-datepicker-2-after-css.png');
+
+        // Analyze after CSS
+        const afterAnalysis = await page.evaluate(() => {
+            const results = {
+                imageButtons: []
+            };
+
+            document.querySelectorAll('input[type="image"]').forEach(img => {
+                const rect = img.getBoundingClientRect();
+                const style = getComputedStyle(img);
+                results.imageButtons.push({
+                    id: img.id.substring(img.id.length - 40),
+                    alt: img.alt,
+                    width: rect.width,
+                    height: rect.height,
+                    display: style.display,
+                    visibility: style.visibility,
+                    backgroundColor: style.backgroundColor,
+                    backgroundImage: style.backgroundImage.substring(0, 50) + '...',
+                    visible: rect.width > 0 && rect.height > 0
+                });
+            });
+
+            return results;
+        });
+
+        console.log('\n=== AFTER CSS INJECTION ===');
+        console.log('Image buttons (calendar):', JSON.stringify(afterAnalysis.imageButtons, null, 2));
+
+        console.log('\nKeeping browser open for 15 seconds for inspection...');
+        await sleep(15000);
+
+    } catch (error) {
+        console.error('Error:', error);
+        await page.screenshot({ path: path.join(SCREENSHOT_DIR, 'report-datepicker-error.png'), fullPage: true });
+    } finally {
+        await browser.close();
+    }
+}
+
+testReportDatePicker();


### PR DESCRIPTION
## Summary
- Fixes broken calendar buttons on report pages (e.g., LMS Course Completion Report)
- BusinessCalendar controls have empty `src=""` causing broken images
- CSS now provides visible blue calendar buttons via background-image SVG

## Changes
- Added CSS for `input[type="image"][alt="Use calendar"]` and related selectors
- Blue button (28x28px) with white calendar SVG icon
- Hidden broken image alt text with `font-size:0`, `text-indent:-9999px`
- Added `GridFilterCalendar` table styling for better spacing
- Added `StylesDateText` input styling for date fields
- Included test script `test-report-datepicker.js`

## Test plan
- [x] Login as mcornelius (staff user)
- [x] Navigate to LMS Course Completion Report
- [x] Verify calendar buttons appear as blue buttons with calendar icon
- [x] Verify buttons are clickable

## Before/After
**Before:** Broken image showing "Use calendar" alt text
**After:** Clean blue buttons with white calendar icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)