### PR TITLE
Fix #17: Sticky footer implementation

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,7 +6,13 @@ This document tracks known issues and their status for the PBS Member Portal CSS
 
 ## Open Issues
 
-*No open issues at this time.*
+### Issue #17: Footer floats up when page content is short
+- **Status:** Open
+- **Priority:** Medium
+- **Affected:** All pages with minimal content
+- **Description:** When a page doesn't have enough content to fill the viewport, the footer appears in the middle of the screen instead of staying at the bottom.
+- **Expected:** Footer should always be at the bottom of the viewport (sticky footer), pushing down naturally when content exceeds viewport height.
+- **Branch:** `fix/sticky-footer`
 
 ---
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -16,6 +16,10 @@ This document tracks known issues and their status for the PBS Member Portal CSS
 - **Status:** Resolved (2026-02-05)
 - **Fix:** Updated web.config on both DEV and Production: added `path="/"` and `cookieSameSite="None"` to `<forms>`, added `sameSite="None"` to `<httpCookies>`, and `cookieSameSite="None"` to `<sessionState>`. This prevents duplicate cookies at different paths that caused Chrome to send the wrong cookie first.
 
+### Stale CSS/static content after deployments
+- **Status:** Resolved (2026-02-05)
+- **Fix:** Added `Cache-Control: no-cache` header in web.config `<httpProtocol><customHeaders>` section. Browsers still cache static files but always revalidate with server. After deployments, users get fresh content immediately; unchanged files return 304 Not Modified for fast loads.
+
 ### Issue #36: Panel editor dialog not opening to correct size
 - **Status:** Resolved (2026-02-02)
 - **Fix:** Removed overly broad table width rules from RadWindow dialogs. Added targeted width rules for dialog layout tables and iframe min-width for community dialogs. Disabled "hide empty panel" rule that was hiding dynamic content. Verified working in Chrome and Safari via Playwright cross-browser testing.
@@ -120,4 +124,4 @@ Screenshots are saved to `automatedTestScreenshots/` folder.
 
 ---
 
-*Last updated: 2026-02-05 (Resolved web.config cookie path issue)*
+*Last updated: 2026-02-05 (Resolved stale content caching issue)*

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -6,21 +6,15 @@ This document tracks known issues and their status for the PBS Member Portal CSS
 
 ## Open Issues
 
-### TODO: Fix web.config cookie path to prevent Chrome login redirect loop
-- **Status:** Open
-- **Priority:** Medium
-- **Affected:** DEV and Production
-- **Description:** Chrome users may experience login redirect loops due to duplicate `LoginDEV`/`Login` cookies with different paths. The `<forms>` element has `path="/iMISDEV/"` (DEV) or implicit path (Prod), but cookies may be set at `path=/`, causing duplicates.
-- **Root Cause:** When cookies exist at both `/` and `/iMISDEV/` paths, the browser sends both. The server reads the empty one first and rejects authentication.
-- **Workaround:** Users can clear cookies for the site to resolve temporarily.
-- **Permanent Fix:** Update web.config `<forms>` element to use consistent path:
-  - **DEV (line 156):** Change `path="/iMISDEV/"` to `path="/"`
-  - **Production (line 156):** Add `path="/"`
-- **Also needed:** Add `sameSite="None"` to `<httpCookies>`, `cookieSameSite="None"` to `<forms>` and `<sessionState>` (already done on DEV)
+*No open issues at this time.*
 
 ---
 
 ## Resolved Issues
+
+### Chrome login redirect loop due to cookie path mismatch
+- **Status:** Resolved (2026-02-05)
+- **Fix:** Updated web.config on both DEV and Production: added `path="/"` and `cookieSameSite="None"` to `<forms>`, added `sameSite="None"` to `<httpCookies>`, and `cookieSameSite="None"` to `<sessionState>`. This prevents duplicate cookies at different paths that caused Chrome to send the wrong cookie first.
 
 ### Issue #36: Panel editor dialog not opening to correct size
 - **Status:** Resolved (2026-02-02)
@@ -126,4 +120,4 @@ Screenshots are saved to `automatedTestScreenshots/` folder.
 
 ---
 
-*Last updated: 2026-02-02 (Added web.config cookie path TODO)*
+*Last updated: 2026-02-05 (Resolved web.config cookie path issue)*

--- a/package/pbs-theme.css
+++ b/package/pbs-theme.css
@@ -164,6 +164,31 @@ h4, .SectionLabel, h5 {
     margin-right: 0 !important;
 }
 
+/* ========================================
+   STICKY FOOTER
+   Footer stays at bottom of viewport when content is short,
+   pushes down naturally when content exceeds viewport height.
+   ======================================== */
+html, body {
+    height: 100% !important;
+    margin: 0 !important;
+}
+
+#doc,
+#doc3 {
+    display: flex !important;
+    flex-direction: column !important;
+    min-height: 100vh !important;
+}
+
+#bd {
+    flex: 1 0 auto !important;
+}
+
+#ft {
+    flex-shrink: 0 !important;
+}
+
 /* Header area - contains nav - force full width */
 #hd,
 #hd > div,

--- a/package/pbs-theme.css
+++ b/package/pbs-theme.css
@@ -171,14 +171,20 @@ h4, .SectionLabel, h5 {
    ======================================== */
 html, body {
     height: 100% !important;
+    min-height: 100vh !important;
     margin: 0 !important;
+    background-color: var(--pbs-blue, #164F90) !important;
 }
 
+/* Target all possible YUI doc containers */
 #doc,
-#doc3 {
+#doc2,
+#doc3,
+#doc4 {
     display: flex !important;
     flex-direction: column !important;
     min-height: 100vh !important;
+    background-color: #f5f5f5 !important;
 }
 
 #bd {
@@ -186,7 +192,13 @@ html, body {
 }
 
 #ft {
-    flex-shrink: 0 !important;
+    flex: 0 0 auto !important;
+    margin-top: auto !important;
+    /* Ensure footer fills remaining space at bottom */
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: flex-start !important;
+    min-height: 0 !important;
 }
 
 /* Header area - contains nav - force full width */


### PR DESCRIPTION
## Summary
- Implements sticky footer using CSS flexbox so footer stays at bottom of viewport on pages with minimal content
- Added support for all YUI doc containers (#doc, #doc2, #doc3, #doc4)
- Set html/body background to match footer color for seamless appearance

## Test plan
- [x] Tested on login page (short content) - footer at bottom
- [x] Verified no visual gap between footer and viewport edge
- [x] Tested in Chrome

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)